### PR TITLE
fix: preserve day-color backgrounds when printing worksheets

### DIFF
--- a/src/worksheet_html_renderer.py
+++ b/src/worksheet_html_renderer.py
@@ -79,6 +79,7 @@ _CSS = """\
   @media print {
     body { background: white; padding: 0; }
     .page { padding: 0; box-shadow: none; margin: 0; }
+    * { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
   }
 
   /* Day header bar */


### PR DESCRIPTION
## Summary

- Adds `print-color-adjust: exact` (and `-webkit-` vendor prefix) to the `@media print` block in `worksheet_html_renderer.py`
- Browsers strip background colors by default when printing; this flag forces the day-palette accent colors (Monday blue, Tuesday green, etc.) to render on paper and in PDF export

## Test Plan

- [ ] Open a worksheet packet in the browser and print/export to PDF
- [ ] Confirm the day-header bar retains its color accent (e.g., blue for Monday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)