### PR TITLE
fix: wire Submit Feedback button on dashboard to /plans

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Card, Button, Badge } from '@/components/ui';
 import { Navigation } from '@/components/Navigation';
 import { useEnrichedStudents, useWeeklyPacketsStats, usePendingPackets } from '@/lib/hooks';
@@ -13,6 +14,7 @@ export default function Dashboard() {
   const { packets: pendingPackets } = usePendingPackets();
   const { showToast } = useToast();
 
+  const router = useRouter();
   const [generateModalOpen, setGenerateModalOpen] = useState(false);
   const [selectedStudent, setSelectedStudent] = useState<{
     id: string;
@@ -276,7 +278,12 @@ export default function Dashboard() {
 
                       if (hasPendingPacket) {
                         return (
-                          <Button variant="primary" size="md" className="w-full">
+                          <Button
+                            variant="primary"
+                            size="md"
+                            className="w-full"
+                            onClick={() => router.push('/plans')}
+                          >
                             Submit Feedback
                           </Button>
                         );

--- a/frontend/e2e/feedback.spec.ts
+++ b/frontend/e2e/feedback.spec.ts
@@ -2,6 +2,31 @@ import { test, expect } from '@playwright/test';
 import { createStudent, createPacket, submitFeedback, backdateFeedback } from './fixtures/api';
 
 // ---------------------------------------------------------------------------
+// Dashboard — Submit Feedback button
+// ---------------------------------------------------------------------------
+test.describe('Dashboard — Submit Feedback button', () => {
+  const STUDENT_ID = 'e2e-dashboard-feedback-p5q6';
+  const PACKET_ID = `${STUDENT_ID}-pkt-001`;
+
+  test.beforeAll(async ({ request }) => {
+    await createStudent(request, STUDENT_ID, {
+      name: 'Dashboard Feedback Student',
+      birthday: '2018-08-01',
+    });
+    await createPacket(request, STUDENT_ID, PACKET_ID);
+  });
+
+  test('Submit Feedback button on dashboard navigates to /plans', async ({ page }) => {
+    // networkidle ensures both students AND packets have loaded (two-stage async fetch)
+    await page.goto('/dashboard', { waitUntil: 'networkidle' });
+    const btn = page.getByRole('button', { name: 'Submit Feedback' }).first();
+    await expect(btn).toBeVisible();
+    await btn.click();
+    await expect(page).toHaveURL(/\/plans/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Plans page — empty state
 // ---------------------------------------------------------------------------
 test.describe('Plans page — empty state', () => {


### PR DESCRIPTION
## Summary

- The Submit Feedback button on the dashboard card had no `onClick` handler — clicking it did nothing
- Root cause: `dashboard/page.tsx` rendered the button with no action attached
- Fix: added `useRouter` import and `onClick={() => router.push('/plans')}` so the button navigates to the Plans page where the full feedback flow (plan detail modal → feedback modal) lives

## Test plan

- [ ] New E2E test: `Dashboard — Submit Feedback button › Submit Feedback button on dashboard navigates to /plans`
  - Seeds a student with a ready packet
  - Navigates to `/dashboard` with `waitUntil: 'networkidle'` (required because dashboard has a two-stage async load: students first, then packets)
  - Verifies the Submit Feedback button appears
  - Clicks it and asserts the URL changes to `/plans`

🤖 Generated with [Claude Code](https://claude.com/claude-code)