### PR TITLE
fix: narrow OperationalError catch in delete_student to table-not-found only

### DIFF
--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -261,8 +261,9 @@ def delete_student(student_id: str) -> bool:
         # weekly_packets may not exist in minimal test DBs, so ignore if absent.
         try:
             cursor.execute("DELETE FROM weekly_packets WHERE student_id = ?", (student_id,))
-        except sqlite3.OperationalError:
-            pass
+        except sqlite3.OperationalError as e:
+            if "no such table" not in str(e):
+                raise
         cursor.execute(
             "DELETE FROM student_profiles WHERE student_id = ?",
             (student_id,),


### PR DESCRIPTION
## Summary

- The existing `except sqlite3.OperationalError: pass` in `delete_student` was introduced in PR#85 to handle the case where `weekly_packets` doesn't exist in minimal test DBs.
- However, `sqlite3.OperationalError` is a wide exception class that also covers disk-full errors, database-locked errors, corrupted database pages, and future typos in table names — all of which were silently swallowed with `pass`.
- This fix narrows the handler to check `"no such table" in str(e)` and re-raises any other `OperationalError`, so real failures surface immediately rather than being hidden.

## Test plan

- [ ] Verify that deleting a student against a minimal test DB (without `weekly_packets`) still succeeds without error
- [ ] Verify that a simulated non-table `OperationalError` (e.g. "database is locked") is now propagated rather than suppressed
- [ ] Run `pytest tests/ -k "delete" -v` once a Python 3.11+ environment is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)