### PR TITLE
fix: grade_level fallback should be 0 (Kindergarten) not 1, handle empty metadata dict

### DIFF
--- a/src/trio_generator.py
+++ b/src/trio_generator.py
@@ -18,14 +18,14 @@ logger = logging.getLogger(__name__)
 def _get_grade_level(student_id: str, metadata_fallback: dict | None = None) -> int:
     """Return grade_level from the student's most recent weekly packet.
 
-    Falls back to metadata_fallback["grade_level"] if no packets exist, then to 1.
+    Falls back to metadata_fallback["grade_level"] if no packets exist, then to 0.
     """
     packets, _ = list_weekly_packets(student_id, limit=1, offset=0)
     if packets:
         return packets[0].get("grade_level", 0)
-    if metadata_fallback:
-        return int(metadata_fallback.get("grade_level", 1))
-    return 1
+    if metadata_fallback is not None:
+        return int(metadata_fallback.get("grade_level", 0))
+    return 0
 
 
 def generate_trio_for_student(student_id: str) -> None:

--- a/tests/test_trio_generator.py
+++ b/tests/test_trio_generator.py
@@ -60,11 +60,23 @@ def test_get_grade_level_from_most_recent_packet():
         assert trio_generator._get_grade_level("s1") == 3
 
 
-def test_get_grade_level_defaults_to_one_when_no_packets():
+def test_get_grade_level_defaults_to_zero_when_no_packets():
     with patch("trio_generator.list_weekly_packets", return_value=([], False)):
-        assert trio_generator._get_grade_level("s1") == 1
+        assert trio_generator._get_grade_level("s1") == 0
 
 
 def test_get_grade_level_uses_metadata_fallback_when_no_packets():
     with patch("trio_generator.list_weekly_packets", return_value=([], False)):
         assert trio_generator._get_grade_level("s1", metadata_fallback={"grade_level": 4}) == 4
+
+
+def test_get_grade_level_empty_metadata_dict_falls_back_to_zero():
+    """An empty metadata dict ({}) must not be treated as falsy — grade must default to 0."""
+    with patch("trio_generator.list_weekly_packets", return_value=([], False)):
+        assert trio_generator._get_grade_level("s1", metadata_fallback={}) == 0
+
+
+def test_get_grade_level_kindergarten_metadata_returns_zero():
+    """metadata_fallback with grade_level=0 (Kindergarten) must return 0, not 1."""
+    with patch("trio_generator.list_weekly_packets", return_value=([], False)):
+        assert trio_generator._get_grade_level("s1", metadata_fallback={"grade_level": 0}) == 0


### PR DESCRIPTION
## Summary

- **Grade 0 is Kindergarten** per the standards schema. The previous hard-coded fallback of `1` caused new Kindergarten students (who have no weekly packets yet) to receive grade-1 lesson plans.
- **Empty metadata dict `{}` was falsy**, so `if metadata_fallback:` skipped the fallback branch entirely for students whose `metadata_blob` deserialized to `{}`. This meant `_get_grade_level` fell straight through to `return 1` even when a fallback dict was provided.
- Both bugs combined meant any new Kindergarten student — or any student with a minimal/empty metadata blob — silently got grade-1 content.

### Changes

- `src/trio_generator.py`: `if metadata_fallback:` → `if metadata_fallback is not None:` to correctly handle the empty-dict case
- `src/trio_generator.py`: all default/fallback values changed from `1` to `0` (Kindergarten is the safe default)
- `src/trio_generator.py`: docstring updated to reflect new fallback value
- `tests/test_trio_generator.py`: renamed `test_get_grade_level_defaults_to_one_when_no_packets` → `test_get_grade_level_defaults_to_zero_when_no_packets` and updated assertion to `== 0`
- `tests/test_trio_generator.py`: added `test_get_grade_level_empty_metadata_dict_falls_back_to_zero` — exercises the empty-dict falsy bug
- `tests/test_trio_generator.py`: added `test_get_grade_level_kindergarten_metadata_returns_zero` — ensures `grade_level=0` in metadata is preserved and not overridden

## Test plan

- [ ] `tests/test_trio_generator.py` passes on Python 3.11 CI (local Python 3.10 cannot import `datetime.UTC` from `agent.py`, a pre-existing environment limitation)
- [ ] `test_get_grade_level_defaults_to_zero_when_no_packets` asserts `== 0`
- [ ] `test_get_grade_level_empty_metadata_dict_falls_back_to_zero` passes (new test)
- [ ] `test_get_grade_level_kindergarten_metadata_returns_zero` passes (new test)
- [ ] All pre-existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)