### PR TITLE
fix: preserve packet_feedback and created_at on packet re-save

### DIFF
--- a/src/packet_store.py
+++ b/src/packet_store.py
@@ -172,7 +172,7 @@ def _insert_weekly_packet(
 
     conn.execute(
         """
-        INSERT OR REPLACE INTO weekly_packets (
+        INSERT INTO weekly_packets (
             packet_id,
             student_id,
             grade_level,
@@ -185,6 +185,16 @@ def _insert_weekly_packet(
             created_at,
             updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(packet_id) DO UPDATE SET
+            student_id = excluded.student_id,
+            grade_level = excluded.grade_level,
+            subject = excluded.subject,
+            week_of = excluded.week_of,
+            status = excluded.status,
+            weekly_overview = excluded.weekly_overview,
+            summary_json = excluded.summary_json,
+            payload_json = excluded.payload_json,
+            updated_at = excluded.updated_at
         """,
         (
             weekly_plan.get("plan_id"),
@@ -302,6 +312,7 @@ def save_weekly_packet(
 
     with _get_connection() as conn:
         _insert_weekly_packet(conn, weekly_plan, status)
+        conn.execute("DELETE FROM daily_lessons WHERE packet_id = ?", (packet_id,))
         _persist_daily_lessons(conn, packet_id, weekly_plan.get("daily_plan", []))
 
 

--- a/tests/test_packet_store.py
+++ b/tests/test_packet_store.py
@@ -134,6 +134,71 @@ def test_list_packet_artifacts_enforces_ownership(tmp_path):
     assert unauthorized is None
 
 
+def test_resave_preserves_packet_feedback(tmp_path):
+    """Regression: re-saving a packet must not cascade-delete packet_feedback."""
+    db_path = tmp_path / "packets.db"
+    packet_store = _reload_modules(db_path)
+
+    plan = build_weekly_plan(plan_id="plan_feedback_test")
+    packet_store.save_weekly_packet(plan)
+
+    # Save feedback for the packet
+    packet_store.save_packet_feedback(
+        "student-123",
+        "plan_feedback_test",
+        {"Monday": "great"},
+        5,
+    )
+
+    # Verify feedback was saved
+    feedback_before = packet_store.get_packet_feedback("student-123", "plan_feedback_test")
+    assert feedback_before is not None
+    assert feedback_before["quantity_feedback"] == 5
+
+    # Re-save the same packet (simulating the background re-generation after feedback)
+    packet_store.save_weekly_packet(plan)
+
+    # Feedback must still be present after the re-save
+    feedback_after = packet_store.get_packet_feedback("student-123", "plan_feedback_test")
+    assert feedback_after is not None, "packet_feedback was deleted by re-save (cascade bug)"
+    assert feedback_after["quantity_feedback"] == 5
+    assert feedback_after["mastery_feedback"] == {"Monday": "great"}
+
+
+def test_resave_does_not_overwrite_created_at(tmp_path):
+    """Regression: re-saving a packet must not overwrite the original created_at."""
+    db_path = tmp_path / "packets.db"
+    packet_store = _reload_modules(db_path)
+
+    plan = build_weekly_plan(plan_id="plan_created_at_test")
+    packet_store.save_weekly_packet(plan)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    original_created_at = conn.execute(
+        "SELECT created_at FROM weekly_packets WHERE packet_id = ?",
+        ("plan_created_at_test",),
+    ).fetchone()["created_at"]
+    conn.close()
+
+    # Re-save the same packet
+    packet_store.save_weekly_packet(plan)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row_after = conn.execute(
+        "SELECT created_at, updated_at FROM weekly_packets WHERE packet_id = ?",
+        ("plan_created_at_test",),
+    ).fetchone()
+    conn.close()
+
+    assert row_after["created_at"] == original_created_at, (
+        "created_at was overwritten on re-save"
+    )
+    # updated_at may be the same if re-save is fast, but created_at must not change
+    assert row_after["updated_at"] is not None
+
+
 def test_get_artifact_for_student_returns_none_when_mismatch(tmp_path):
     db_path = tmp_path / "packets.db"
     packet_store = _reload_modules(db_path)


### PR DESCRIPTION
## Summary

- **Bug A (data loss):** `INSERT OR REPLACE` in `_insert_weekly_packet` triggers a SQLite-internal DELETE + INSERT on primary key conflict. With `FOREIGN KEY ... ON DELETE CASCADE` on `packet_feedback`, this silently deletes all user-submitted feedback on every packet re-save. Since `generate_trio_for_student` is called as a background task after every feedback submission, feedback was being erased immediately after submission.
- **Bug B (audit timestamp):** Both `created_at` and `updated_at` were set to `now` on every call, overwriting the original creation timestamp on re-saves.

## Changes

- **`src/packet_store.py`** — Replace `INSERT OR REPLACE INTO weekly_packets` with `INSERT INTO ... ON CONFLICT(packet_id) DO UPDATE SET ...`. The upsert updates the row in-place without deleting it, so the `ON DELETE CASCADE` to `packet_feedback` never fires. `created_at` is intentionally excluded from the `DO UPDATE SET` list so it is only written on the first insert.
- **`src/packet_store.py`** — Add `conn.execute("DELETE FROM daily_lessons WHERE packet_id = ?", ...)` in `save_weekly_packet` before `_persist_daily_lessons`. This explicit delete replaces the implicit cascade cleanup that the old DELETE approach provided, since `_persist_daily_lessons` uses plain `INSERT` (not `INSERT OR IGNORE`) and would fail on UNIQUE constraint for `(packet_id, day_label)` without it.
- **`tests/test_packet_store.py`** — Add `test_resave_preserves_packet_feedback`: saves a packet, saves feedback, re-saves the packet, asserts feedback is still present. Add `test_resave_does_not_overwrite_created_at`: saves a packet, re-saves it, asserts `created_at` is unchanged.

## Test plan

- [ ] `test_resave_preserves_packet_feedback` — confirms feedback rows survive a packet re-save
- [ ] `test_resave_does_not_overwrite_created_at` — confirms `created_at` is immutable after first insert
- [ ] Existing `test_save_weekly_packet_persists_rows` — confirms initial save still writes all rows correctly
- [ ] Existing `test_save_weekly_packet_rolls_back_on_error` — confirms transaction atomicity is preserved
- [ ] CI runs on Python 3.12 where `datetime.UTC` is available (local env is 3.10; import error is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)